### PR TITLE
Use NuGet for HugsLib and Harmony dependencies

### DIFF
--- a/Source/RimWorldOnlineCity/RimWorldOnlineCity.csproj
+++ b/Source/RimWorldOnlineCity/RimWorldOnlineCity.csproj
@@ -31,23 +31,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="%24HugsLibChecker, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>Lib\$HugsLibChecker.dll</HintPath>
+    <Reference Include="$HugsLibChecker, Version=0.5.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>packages\UnlimitedHugs.Rimworld.HugsLibChecker.5.0.0\lib\net35\$HugsLibChecker.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="0Harmony">
-      <HintPath>$(RimWorldFolder)Mods\HugsLib\Assemblies\0Harmony.dll</HintPath>
-      <!--HintPath>$(SteamWorkShopFolder)818773962\Assemblies\0Harmony.dll</HintPath-->
-      <Private>False</Private>
+    <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, PublicKeyToken=null">
+      <HintPath>packages\UnlimitedHugs.Rimworld.HugsLib.6.1.1\lib\net35\0Harmony.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>$(RimWorldFolder)RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="HugsLib">
-      <HintPath>$(RimWorldFolder)Mods\HugsLib\Assemblies\HugsLib.dll</HintPath>
-      <!--HintPath>$(SteamWorkShopFolder)818773962\Assemblies\HugsLib.dll</HintPath-->
-      <Private>False</Private>
+    <Reference Include="HugsLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>packages\UnlimitedHugs.Rimworld.HugsLib.6.1.1\lib\net35\HugsLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
@@ -110,6 +108,9 @@
       <Project>{9513586e-b487-4bee-a3fb-0d277d4e5b5c}</Project>
       <Name>UnionDll</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/RimWorldOnlineCity/packages.config
+++ b/Source/RimWorldOnlineCity/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Lib.Harmony" version="1.2.0.1" targetFramework="net35" />
+  <package id="UnlimitedHugs.Rimworld.HugsLib" version="6.1.1" targetFramework="net35" />
+  <package id="UnlimitedHugs.Rimworld.HugsLibChecker" version="5.0.0" targetFramework="net35" />
+</packages>


### PR DESCRIPTION
No need to reference arbitrary DLLs when NuGet can get them for you. By default, both Visual Studio and JetBrains Rider will attempt to download NuGet dependencies, so it makes setup much easier for new environments.